### PR TITLE
Comment out sorting until parsed JSON is returned

### DIFF
--- a/en/build/service.md
+++ b/en/build/service.md
@@ -102,7 +102,7 @@ module.exports = class ReportService extends Service {
    */
   getLatest (cik) {
     return this.getEdgarListings(cik)
-      .then(list => list.sort(f => (0 - f.filingDate.valueOf())))
+      //.then(list => list.sort(f => (0 - f.filingDate.valueOf())))
       .then(([ filing ]) => filing)
   }
 


### PR DESCRIPTION
1. Should there be a note to 'npm install' the new reqs? 'boom', 'request-promise'...
2. Line  95: 'querystring' is not used.
3. Line 116: This was not working for me `${edgarAtomUrl}?${query}`
4. Line 127: returns an object
5. Line 105: Commented out until there is parsed JSON to sort